### PR TITLE
Improve storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Compiled python modules.
+*.pyc
+
+# Setuptools distribution folder.
+/dist/
+
+# Python egg metadata, regenerated from source files by setuptools.
+/*.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 
 # Python egg metadata, regenerated from source files by setuptools.
 /*.egg-info
+
+tzdata.p

--- a/adapters/adapter.py
+++ b/adapters/adapter.py
@@ -1,0 +1,23 @@
+from abc import ABCMeta, abstractmethod
+
+class Adapter(metaclass=ABCMeta):
+    @abstractmethod
+    def load(self):
+        pass
+
+    @abstractmethod
+    def __setitem__(self, key, item):
+        pass
+
+    @abstractmethod
+    def __getitem__(self, key):
+        pass
+
+    @abstractmethod
+    def items(self):
+        pass
+
+    @abstractmethod
+    def store(self):
+        pass
+

--- a/adapters/adapter.py
+++ b/adapters/adapter.py
@@ -1,5 +1,11 @@
 from abc import ABCMeta, abstractmethod
 
+# This is a metaclass
+#
+# Pretty much means that it just defines methods we want specific implemenations
+# to have, without actually implementing anything.
+#
+# A simple description of what an Adapter can do, without doing anything
 class Adapter(metaclass=ABCMeta):
     @abstractmethod
     def load(self):

--- a/adapters/json_adapter.py
+++ b/adapters/json_adapter.py
@@ -1,0 +1,51 @@
+from adapters.adapter import Adapter
+from pathlib import Path
+import os
+
+import json
+
+class JSONAdapter(Adapter):
+    """A Dummy storage adapter that does stores the data in
+    in-memory dict and doesn't persist to disk.
+
+    Used for testing
+    """
+    DB_PATH = "tzdata.json"
+
+    # allow specifying custom db path for tests so that we don't override prod
+    def __init__(self, db_path = DB_PATH):
+        self.db_path = db_path
+
+    def load(self):
+        # check if file exists
+        if self.storage_exists() and self.storage_not_empty():
+            # this will safely open the file and then close if after it exits the block
+            with open(self.db_path, 'r') as f:
+                self.data = json.load(f)
+
+        else:
+            # if we don't have storage initialize it and create the file
+            self.data = {}
+            self.store()
+
+    def __setitem__(self, key, item):
+        self.data[key] = item
+
+    def __getitem__(self, key):
+        return self.data[key]
+
+    def items(self):
+        return self.data.items()
+
+    def store(self):
+        # yet again we safely open the file and make sure it's closed
+        # when we close it data is flished to the disk
+        with open(self.db_path, 'w') as f:
+            json.dump(self.data, f)
+
+    # check if the file exists
+    def storage_exists(self):
+        return Path(self.db_path).is_file()
+
+    def storage_not_empty(self):
+        return (os.path.getsize(self.db_path) > 0)

--- a/adapters/json_adapter.py
+++ b/adapters/json_adapter.py
@@ -5,10 +5,8 @@ import os
 import json
 
 class JSONAdapter(Adapter):
-    """A Dummy storage adapter that does stores the data in
-    in-memory dict and doesn't persist to disk.
-
-    Used for testing
+    """
+    Adapter used for storing JSON
     """
     DB_PATH = "tzdata.json"
 

--- a/adapters/legacy_adapter.py
+++ b/adapters/legacy_adapter.py
@@ -5,10 +5,8 @@ import os
 import pickle
 
 class LegacyAdapter(Adapter):
-    """A Dummy storage adapter that does stores the data in
-    in-memory dict and doesn't persist to disk.
-
-    Used for testing
+    """
+    Same data structure as originally designed
     """
     DB_PATH = "tzdata.p"
 

--- a/adapters/legacy_adapter.py
+++ b/adapters/legacy_adapter.py
@@ -1,0 +1,53 @@
+from adapters.adapter import Adapter
+from pathlib import Path
+import os
+
+import pickle
+
+class LegacyAdapter(Adapter):
+    """A Dummy storage adapter that does stores the data in
+    in-memory dict and doesn't persist to disk.
+
+    Used for testing
+    """
+    DB_PATH = "tzdata.p"
+
+    # allow specifying custom db path for tests so that we don't override prod
+    def __init__(self, db_path = DB_PATH):
+        self.db_path = db_path
+
+    def load(self):
+        # check if file exists
+        if self.storage_exists() and self.storage_not_empty():
+            # this will safely open the file and then close if after it exits the block
+            with open(self.db_path, 'rb') as f:
+                self.data = pickle.load(f)
+
+        else:
+            # if we don't have storage initialize it and create the file
+            self.data = {}
+            self.store()
+
+    def __setitem__(self, key, item):
+        self.data[key] = item
+
+    def __getitem__(self, key):
+        return self.data[key]
+
+    def items(self):
+        return self.data.items()
+
+    def store(self):
+        # yet again we safely open the file and make sure it's closed
+        # when we close it data is flished to the disk
+        with open(self.db_path, 'wb') as f:
+            pickle.dump(self.data, f)
+
+    # check if the file exists
+    def storage_exists(self):
+        return Path(self.db_path).is_file()
+
+    def storage_not_empty(self):
+        return (os.path.getsize(self.db_path) > 0)
+
+

--- a/adapters/memory_adapter.py
+++ b/adapters/memory_adapter.py
@@ -1,0 +1,22 @@
+from adapters.adapter import Adapter
+
+class MemoryAdapter(Adapter):
+    """A Dummy storage adapter that does stores the data in
+    in-memory dict and doesn't persist to disk.
+
+    Used for testing
+    """
+    def load(self):
+        self.data = {}
+
+    def __setitem__(self, key, item):
+        self.data[key] = item
+
+    def __getitem__(self, key):
+        return self.data[key]
+
+    def items(self):
+        return self.data.items()
+
+    def store(self):
+        pass

--- a/discordbot.py
+++ b/discordbot.py
@@ -4,7 +4,6 @@ from dateutil.parser import parse
 from dateutil.tz import gettz
 from pytz import timezone
 from time import gmtime, strftime
-import pickle
 
 logging.basicConfig(level=logging.CRITICAL)
 client = discord.Client()
@@ -19,7 +18,10 @@ EST_tz = gettz("America/New York")
 
 timezone_var = {}
 
-timezone_var = pickle.load( open( "tzdata.p", "rb" ) )
+from repository import Repository
+from adapters.legacy_adapter import LegacyAdapter
+timezone_var = Repository(LegacyAdapter())
+#timezone_var = pickle.load( open( "tzdata.p", "rb" ) )
 
 
 @client.event
@@ -28,7 +30,8 @@ async def on_message(message):
 	if message.author == client.user:
 		return
 	# standard list of timezones for given time.
-	timezone_var = pickle.load( open( "tzdata.p", "rb" ) )
+	#timezone_var = pickle.load( open( "tzdata.p", "rb" ) )
+	timezone_var = Repository(LegacyAdapter())
 
 	if message.content.startswith('!tzlist'):
 		try:
@@ -50,7 +53,7 @@ async def on_message(message):
 		else:
 			timezone_var[message.author.id] = msg_list[1]
 			# Save file
-			pickle.dump( timezone_var, open( "tzdata.p", "wb" ) )
+			timezone_var.store()
 			# Respond to user
 			resp = "Request successful <@" + str(message.author.id) + ">"
 			await client.send_message(message.channel, resp)

--- a/migrate_to_json.py
+++ b/migrate_to_json.py
@@ -1,0 +1,11 @@
+from repository import Repository
+from adapters.legacy_adapter import LegacyAdapter
+from adapters.json_adapter import JSONAdapter
+
+legacy = Repository(LegacyAdapter())
+json = Repository(JSONAdapter("migrated.json"))
+
+for key, value in legacy.items():
+    json[key] = value
+
+json.store()

--- a/repository.py
+++ b/repository.py
@@ -2,22 +2,30 @@ from adapters.memory_adapter import MemoryAdapter
 
 class Repository:
     """A simple Repository pattern that supports adapters"""
+
+    # by default we attach the memory adapter that has no persistance
     def __init__(self, adapter = MemoryAdapter()):
         self.adapter = adapter
         self.adapter.load()
 
-    def load(self):
-        self.adapter.load
 
+    # simply proxy to the adapter
+    def load(self):
+        self.adapter.load()
+
+    # __setitem__ is a special method that allows [key]=val to work on objects
     def __setitem__(self, key, item):
         self.adapter[key] = item
 
+    # __getitem__ is a special method that allows [key] to return a value
     def __getitem__(self, key):
         return self.adapter[key]
 
+    # proxy to the adapter
     def items(self):
         return self.adapter.items()
 
+    # proxy to the adapter
     def store(self):
         self.adapter.store()
 

--- a/repository.py
+++ b/repository.py
@@ -1,0 +1,25 @@
+from adapters.memory_adapter import MemoryAdapter
+
+class Repository:
+    """A simple Repository pattern that supports adapters"""
+    def __init__(self, adapter = MemoryAdapter()):
+        self.adapter = adapter
+        self.adapter.load()
+
+    def load(self):
+        self.adapter.load
+
+    def __setitem__(self, key, item):
+        self.adapter[key] = item
+
+    def __getitem__(self, key):
+        return self.adapter[key]
+
+    def items(self):
+        return self.adapter.items()
+
+    def store(self):
+        self.adapter.store()
+
+
+

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup
+
+setup(name='timezonebot',
+      version='0.1',
+      description='Discord time zone bot',
+      url='https://github.com/nathanrsm/timezonebot',
+      author='Nath',
+      author_email='nath@crucible.gods',
+      license='MIT',
+      packages=['timezonebot'],
+      install_requires=[
+          'pytz',
+          'python-dateutil',
+          'discord.py',
+          ],
+      zip_safe=False)

--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -1,0 +1,29 @@
+import unittest
+
+from repository import Repository
+
+class TestRepository(unittest.TestCase):
+    def setUp(self):
+        self.repo = Repository()
+
+    def test_default_adapter(self):
+        self.assertTrue(self.repo.adapter)
+
+    def test_load(self):
+        self.assertTrue(self.repo.load)
+
+    def test_set_get(self):
+        self.repo["id"] = "value"
+        self.repo["id1"] = "value1"
+
+        self.assertEqual("value", self.repo["id"])
+        self.assertEqual("value1", self.repo["id1"])
+
+    def test_items(self):
+        self.repo["id"] = "value"
+        self.repo["id1"] = "value1"
+
+        self.assertEqual([('id', 'value'), ('id1', 'value1')], list(self.repo.items()))
+
+    def test_store(self):
+        self.repo.store()

--- a/test/test_repository_json.py
+++ b/test/test_repository_json.py
@@ -1,0 +1,40 @@
+import unittest
+import tempfile
+
+from repository import Repository
+from adapters.json_adapter import JSONAdapter
+
+class TestRepositoryJSON(unittest.TestCase):
+    def setUp(self):
+        self.temp_file = tempfile.NamedTemporaryFile()
+        self.repo = Repository(JSONAdapter(self.temp_file.name))
+
+    def tearDown(self):
+        self.temp_file.close()
+
+    def test_set_get(self):
+        self.repo["id"] = "value"
+        self.repo["id1"] = "value1"
+
+        self.assertEqual("value", self.repo["id"])
+        self.assertEqual("value1", self.repo["id1"])
+
+    def test_items(self):
+        self.repo["id"] = "value"
+        self.repo["id1"] = "value1"
+
+        self.assertEqual([('id', 'value'), ('id1', 'value1')], list(self.repo.items()))
+
+    def test_persistance(self):
+        self.repo["id"] = "value"
+        self.repo["id1"] = "value1"
+
+        self.repo.store()
+
+        new_repo = Repository(JSONAdapter(self.temp_file.name))
+
+        self.assertEqual([('id', 'value'), ('id1', 'value1')], list(new_repo.items()))
+
+
+        self.assertEqual("value", new_repo["id"])
+        self.assertEqual("value1", new_repo["id1"])

--- a/test/test_repository_legacy.py
+++ b/test/test_repository_legacy.py
@@ -1,0 +1,40 @@
+import unittest
+import tempfile
+
+from repository import Repository
+from adapters.legacy_adapter import LegacyAdapter
+
+class TestRepositoryLegacy(unittest.TestCase):
+    def setUp(self):
+        self.temp_file = tempfile.NamedTemporaryFile()
+        self.repo = Repository(LegacyAdapter(self.temp_file.name))
+
+    def tearDown(self):
+        self.temp_file.close()
+
+    def test_set_get(self):
+        self.repo["id"] = "value"
+        self.repo["id1"] = "value1"
+
+        self.assertEqual("value", self.repo["id"])
+        self.assertEqual("value1", self.repo["id1"])
+
+    def test_items(self):
+        self.repo["id"] = "value"
+        self.repo["id1"] = "value1"
+
+        self.assertEqual([('id', 'value'), ('id1', 'value1')], list(self.repo.items()))
+
+    def test_persistance(self):
+        self.repo["id"] = "value"
+        self.repo["id1"] = "value1"
+
+        self.repo.store()
+
+        new_repo = Repository(LegacyAdapter(self.temp_file.name))
+
+        self.assertEqual([('id', 'value'), ('id1', 'value1')], list(new_repo.items()))
+
+
+        self.assertEqual("value", new_repo["id"])
+        self.assertEqual("value1", new_repo["id1"])


### PR DESCRIPTION
This does a few things:

 * adds a setup.py so that we can install dependencies with  `python setup.py build`
 * adds a test suite runnable with `python3 -m unittest discover -s test/`
* Adds a `Repository` with different adapters

Ok, so. `pickle` is not "not great" to put it lightly. A way better serialisation is JSON. So I wrote a big thing that supports both JSON and Pickle and a migration script for the current DB.


```python mimigrate_to_json.py```

To be honest none of this matters that much. It's mostly a demonstration of how Object Oriented Code looks in python. And that tests are super cool and help a lot.

If you wanna change the storage just replace `LegacyAdapter` with `JSONAdapter` in the main thing once the data is migrated.


**NOTE**: I checked the calendar and I haven't done python in 8 years, so I'm a bit rusty to say the least